### PR TITLE
Added support to showing the screen, and some reworking on the class casioplot_settings

### DIFF
--- a/casioplot/__init__.py
+++ b/casioplot/__init__.py
@@ -3,6 +3,6 @@
 All the public functions and objects from the :py:mod:`casioplot` module are accessible in this package.
 """
 
-from .casioplot import show_screen, set_pixel, draw_string, get_pixel, clear_screen, casioplot_settings, settings
+from .casioplot import show_screen, set_pixel, draw_string, get_pixel, clear_screen, settings
 
 __version__ = "1.3.2"

--- a/casioplot/__init__.py
+++ b/casioplot/__init__.py
@@ -3,6 +3,6 @@
 All the public functions and objects from the :py:mod:`casioplot` module are accessible in this package.
 """
 
-from .casioplot import show_screen, set_pixel, draw_string, get_pixel, clear_screen, settings
+from .casioplot import show_screen, set_pixel, draw_string, get_pixel, clear_screen, casioplot_settings
 
 __version__ = "1.3.2"

--- a/casioplot/__init__.py
+++ b/casioplot/__init__.py
@@ -3,6 +3,6 @@
 All the public functions and objects from the :py:mod:`casioplot` module are accessible in this package.
 """
 
-from .casioplot import show_screen, set_pixel, draw_string, get_pixel, clear_screen, casioplot_settings
+from .casioplot import show_screen, set_pixel, draw_string, get_pixel, clear_screen, casioplot_settings, settings
 
 __version__ = "1.3.2"

--- a/casioplot/casioplot.py
+++ b/casioplot/casioplot.py
@@ -12,17 +12,16 @@ You can also use :py:data:`settings` to change some behavior.
 
 from os import path
 from typing import Literal
-from PIL import Image, ImageDraw
+from PIL import Image
 from configs import get_config
 
 
-_WHITE: tuple[int, int, int] = (255, 255, 255)  # RGBA white
-_BLACK: tuple[int, int, int] = (0, 0, 0)  # RGBA black
+COLOR = tuple[int, int, int]
+_WHITE: COLOR = (255, 255, 255)  # RGBA white
+_BLACK: COLOR = (0, 0, 0)  # RGBA black
 
 # Create virtual screen
 _image: Image.Image = Image.new("RGB", (384, 192), _WHITE)
-# Create drawing object (used by the function draw_string
-_draw: ImageDraw.ImageDraw = ImageDraw.Draw(_image)
 
 
 class casioplot_settings:
@@ -44,9 +43,8 @@ class casioplot_settings:
         self.open_image: bool = False  # Open the screen
         self.save_image: bool = True  # Save the screen as an image
         # Saving settings
-        self.filename: str = 'casioplot.png'
-        self.image_format: str = 'png'
-
+        self.filename: str = "casioplot.png"
+        self.image_format: str = "png"
 
     def config_to(self, config: str = "default") -> None:
         global _image
@@ -54,13 +52,11 @@ class casioplot_settings:
             setattr(self, setting, value)
         _image = self.background_image
 
-
     def set(self, **settings) -> None:
         """Set an attribute for each given setting with the corresponding value."""
         for setting, value in settings.items():
             setattr(self, setting, value)
         _redraw_screen()
-
 
     def get(self, setting: str):
         """Returns an attribute"""
@@ -76,21 +72,19 @@ def _redraw_screen() -> None:
     Only called when settings.set() is called,
     used to redraw _image with custom margins, width and height.
     """
-    global _image, _draw
+    global _image
 
     # Create a new white image
     _image = Image.new(
         "RGB",
         (
             settings.left_margin + settings.width + settings.right_margin,
-            settings.top_margin + settings.height + settings.bottom_margin
+            settings.top_margin + settings.height + settings.bottom_margin,
         ),
-        _WHITE
+        _WHITE,
     )
 
     settings.background_image = _image
-
-    _draw = ImageDraw.Draw(_image)
 
 
 def show_screen() -> None:
@@ -115,20 +109,17 @@ def show_screen() -> None:
 def clear_screen() -> None:
     """Clear the virtual screen."""
     show_screen()
-    settings.config_to('default')
+    settings.config_to("default")
 
 
-def get_pixel(x: int, y: int) -> tuple[int, int, int] | None:
+def get_pixel(x: int, y: int) -> COLOR | None:
     """Get the RGB color of the pixel at the given position.
 
     :param x: x coordinate (from the left)
     :param y: y coordinate (from the top)
     :return: The pixel color. A tuple that contain 3 integers from 0 to 255 or None if the pixel is out of the screen.
     """
-    if (
-        not 0 <= x < settings.get("width")
-        or not 0 <= y < settings.get("height")
-    ):
+    if not 0 <= x < settings.get("width") or not 0 <= y < settings.get("height"):
         return None
     r: int
     g: int
@@ -142,17 +133,14 @@ def get_pixel(x: int, y: int) -> tuple[int, int, int] | None:
     return r, g, b
 
 
-def set_pixel(x: int, y: int, color: tuple[int, int, int] = (0, 0, 0)) -> None:
+def set_pixel(x: int, y: int, color: COLOR = _BLACK) -> None:
     """Set the RGB color of the pixel at the given position (from top left)
 
     :param x: x coordinate (from the left)
     :param y: y coordinate (from the top)
     :param color: The pixel color. A tuple that contain 3 integers from 0 to 255.
     """
-    if (
-        not 0 <= x < settings.get("width")
-        or not 0 <= y < settings.get("height")
-    ):
+    if not 0 <= x < settings.get("width") or not 0 <= y < settings.get("height"):
         return
     _image.putpixel(
         (
@@ -172,9 +160,7 @@ def _get_filename(character, size: Literal["small", "medium", "large"] = "medium
     """
     special_chars = {" ": "space"}
     filename = special_chars.get(character, character) + ".txt"
-    file_path = path.join(
-        path.abspath(path.dirname(__file__)), "chars", size, filename
-    )
+    file_path = path.join(path.abspath(path.dirname(__file__)), "chars", size, filename)
 
     if not path.isfile(file_path):
         print(f'WARNING: No character "{character}" found for size "{size}".')
@@ -188,8 +174,9 @@ def draw_string(
     x: int,
     y: int,
     text: str,
-    color: tuple[int, int, int] = (0, 0, 0),
-    size: Literal["small", "medium", "large"] = "medium") -> None:
+    color: COLOR = _BLACK,
+    size: Literal["small", "medium", "large"] = "medium",
+) -> None:
     """Draw a string on the virtual screen with the given RGB color and size.
 
     :param x: x coordinate (from the left)

--- a/casioplot/casioplot.py
+++ b/casioplot/casioplot.py
@@ -7,119 +7,115 @@ Available functions:
   - :py:func:`clear_screen`
   - :py:func:`show_screen`
 
-You can also use :py:data:`casioplot_settings` to change some behavior.
+You can also use :py:data:`settings` to change some behavior.
 """
 
-import os
-
+from os import path
 from typing import Literal
-
 from PIL import Image, ImageDraw
+from configs import get_config
+
 
 _WHITE: tuple[int, int, int] = (255, 255, 255)  # RGBA white
+_BLACK: tuple[int, int, int] = (0, 0, 0)  # RGBA black
 
 # Create virtual screen
-_image: Image.Image = Image.new('RGB', (384, 192), _WHITE)
+_image: Image.Image = Image.new("RGB", (384, 192), _WHITE)
 # Create drawing object (used by the function draw_string
 _draw: ImageDraw.ImageDraw = ImageDraw.Draw(_image)
 
 
 class casioplot_settings:
     """Manage settings for the casioplot module."""
-    
-    class Settings:
-        """Store default settings"""
+
+    def __init__(self) -> None:
+        # all settings are the default ones
         # Size settings
-        width: int = 384  # Screen width in pixels
-        height: int = 192  # Screen height in pixels
-        
-        left_margin: int = 0
-        right_margin: int = 0
-        top_margin: int = 0
-        bottom_margin: int = 0
-        
+        self.width: int = 384  # Screen width in pixels
+        self.height: int = 192  # Screen height in pixels
+        # margins
+        self.left_margin: int = 0
+        self.right_margin: int = 0
+        self.top_margin: int = 0
+        self.bottom_margin: int = 0
+        # background Image
+        self.background_image: Image.Image = Image.new("RGB", (384, 192), _WHITE)
         # Output settings
-        open_image: bool = False  # Open the screen
-        save_image: bool = True  # Save the screen as an image
+        self.open_image: bool = False  # Open the screen
+        self.save_image: bool = True  # Save the screen as an image
         # Saving settings
-        filename: str = "casioplot.png"
-        image_format: str = "png"
-    
-    @classmethod
-    def _clear_screen(cls):
-        """Clear the screen.
-        
-        It creates a new image and assigns it to global _image.
-        """
-        global _image, _draw
-        
-        _image = Image.new('RGB', (
-            cls.left_margin + cls.width + cls.right_margin,
-            cls.top_margin + cls.height + cls.bottom_margin
-        ), _WHITE)  # Create a new white image
-        
-        _draw = ImageDraw.Draw(_image)
-    
-    @classmethod
-    def default(cls):
-        """Restore default parameters from the class to the instance."""
-        for k, v in casioplot_settings.Settings.__dict__.items():
-            setattr(cls, k, v)
-        cls._clear_screen()
-    
-    @classmethod
-    def casio_graph_90_plus_e(cls):
-        """Set the screen in the casio Graph 90+e format."""
-        global _image, _draw
-        cls.width = 384
-        cls.height = 192
-        cls.left_margin = 0
-        cls.right_margin = 0
-        cls.top_margin = 24
-        cls.bottom_margin = 0
-        
-        # Get the path of the template image
-        import os
+        self.filename: str = 'casioplot.png'
+        self.image_format: str = 'png'
 
-        file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                                 'images',
-                                 'CASIO_Graph_90+e_empty.png')
-        _image = Image.open(file_path).convert("RGB")
-        _draw = ImageDraw.Draw(_image)
-    
-    @classmethod
-    def set(cls, **settings):
-        """Set an attribute for each given setting with the corresponding value.
-        """
+
+    def config_to(self, config: str = "default") -> None:
+        global _image
+        for setting, value in get_config(config).items():
+            setattr(self, setting, value)
+        _image = self.background_image
+
+
+    def set(self, **settings) -> None:
+        """Set an attribute for each given setting with the corresponding value."""
         for setting, value in settings.items():
-            setattr(cls, setting, value)
-        cls._clear_screen()
-    
-    @classmethod
-    def get(cls, setting):
-        return cls.__dict__.get(setting, cls.Settings.__dict__.get(setting))
+            setattr(self, setting, value)
+        _redraw_screen()
 
 
-def show_screen():
-    """Show the virtual screen
-    
-    This function implement two modes that can be enabled or disabled using the :py:class:`casioplot_settings`:
-      - Open the screen as an image (enabled using `casioplot_settings.get('open_image')`).
-      - Save the screen to the disk (enabled using `casioplot_settings.get('save_image')`).
-        The image is saved with the filename found in `casioplot_settings.get('filename')`
+    def get(self, setting: str):
+        """Returns an attribute"""
+        return getattr(self, setting)
+
+
+settings = casioplot_settings()
+
+
+def _redraw_screen() -> None:
+    """Redraws _image.
+
+    Only called when settings.set() is called,
+    used to redraw _image with custom margins, width and height.
     """
-    if casioplot_settings.get('open_image'):
+    global _image, _draw
+
+    # Create a new white image
+    _image = Image.new(
+        "RGB",
+        (
+            settings.left_margin + settings.width + settings.right_margin,
+            settings.top_margin + settings.height + settings.bottom_margin
+        ),
+        _WHITE
+    )
+
+    settings.background_image = _image
+
+    _draw = ImageDraw.Draw(_image)
+
+
+def show_screen() -> None:
+    """Show or saves the virtual screen
+
+    This function implement two modes that can be enabled or disabled using the :py:class:`settings`:
+      - Open the screen as an image (enabled using `settings.get('open_image')`).
+      - Save the screen to the disk (enabled using `settings.get('save_image')`).
+        The image is saved with the filename found in `settings.get('filename')`
+    """
+    if settings.get("open_image") is True:
         # open the picture
         _image.show()
-    if casioplot_settings.get('save_image'):
+    if settings.get("save_image") is True:
         # Save the screen to the disk as an image with the given filename
-        _image.save(casioplot_settings.get('filename'), format=casioplot_settings.get('image_format'))
+        _image.save(
+            settings.get("filename"),
+            format=settings.get("image_format"),
+        )
 
 
-def clear_screen():
+def clear_screen() -> None:
     """Clear the virtual screen."""
     show_screen()
-    casioplot_settings.default()
+    settings.config_to('default')
 
 
 def get_pixel(x: int, y: int) -> tuple[int, int, int] | None:
@@ -129,59 +125,73 @@ def get_pixel(x: int, y: int) -> tuple[int, int, int] | None:
     :param y: y coordinate (from the top)
     :return: The pixel color. A tuple that contain 3 integers from 0 to 255 or None if the pixel is out of the screen.
     """
-    if not 0 <= x <= casioplot_settings.get('width') - 1 or not 0 <= y <= casioplot_settings.get('height') - 1:
+    if (
+        not 0 <= x < settings.get("width")
+        or not 0 <= y < settings.get("height")
+    ):
         return None
     r: int
     g: int
     b: int
-    r, g, b = _image.getpixel((x + casioplot_settings.get('left_margin'), y + casioplot_settings.get('top_margin')))
+    r, g, b = _image.getpixel(
+        (
+            x + settings.get("left_margin"),
+            y + settings.get("top_margin"),
+        )
+    )
     return r, g, b
 
 
-def set_pixel(x: int, y: int, color: tuple[int, int, int] = (0, 0, 0)):
+def set_pixel(x: int, y: int, color: tuple[int, int, int] = (0, 0, 0)) -> None:
     """Set the RGB color of the pixel at the given position (from top left)
 
     :param x: x coordinate (from the left)
     :param y: y coordinate (from the top)
     :param color: The pixel color. A tuple that contain 3 integers from 0 to 255.
     """
-    if not 0 <= x < casioplot_settings.get('width') - 1 or not 0 <= y < casioplot_settings.get('height') - 1:
+    if (
+        not 0 <= x < settings.get("width")
+        or not 0 <= y < settings.get("height")
+    ):
         return
-    _image.putpixel((x + casioplot_settings.get('left_margin'), y + casioplot_settings.get('top_margin')), color)
+    _image.putpixel(
+        (
+            x + settings.get("left_margin"),
+            y + settings.get("top_margin"),
+        ),
+        color,
+    )
 
 
 def _get_filename(character, size: Literal["small", "medium", "large"] = "medium"):
     """Get the file where a character is saved and return the ``space`` file if the character doesn't exist.
-    
+
     :param character: The character to find
     :param size: The size of the character
     :return: The character filename. A string: "{``./chars`` folder absolute path}/{character}_{size}.png"
     """
-    special_chars = {
-        ' ': 'space'
-    }
-    filename = special_chars.get(character, character) + '.txt'
-    file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                             'chars',
-                             size,
-                             filename)
+    special_chars = {" ": "space"}
+    filename = special_chars.get(character, character) + ".txt"
+    file_path = path.join(
+        path.abspath(path.dirname(__file__)), "chars", size, filename
+    )
 
-    if not os.path.isfile(file_path):
+    if not path.isfile(file_path):
         print(f'WARNING: No character "{character}" found for size "{size}".')
-        file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                                 'chars',
-                                 size,
-                                 'space.txt')
+        file_path = path.join(
+            path.abspath(path.dirname(__file__)), "chars", size, "space.txt"
+        )
     return file_path
 
 
-def draw_string(x: int,
-                y: int,
-                text: str,
-                color: tuple[int, int, int] = (0, 0, 0),
-                size: Literal["small", "medium", "large"] = "medium"):
+def draw_string(
+    x: int,
+    y: int,
+    text: str,
+    color: tuple[int, int, int] = (0, 0, 0),
+    size: Literal["small", "medium", "large"] = "medium") -> None:
     """Draw a string on the virtual screen with the given RGB color and size.
-    
+
     :param x: x coordinate (from the left)
     :param y: y coordinate (from the top)
     :param text: text that will be shown
@@ -189,24 +199,22 @@ def draw_string(x: int,
     :param size: Size of the text. String from the following values: "small", "medium" or "large".
     :raise ValueError: Raise a ValueError if the size isn't correct.
     """
-    sizes = {
-        'small': (10, 10),
-        'medium': (13, 17),
-        'large': (18, 23)
-    }
-    
+    sizes = {"small": (10, 10), "medium": (13, 17), "large": (18, 23)}
+
     if size not in sizes.keys():
-        raise ValueError(f'Unknown size "{size}". Size must be one of the following: "small", "medium" or "large"')
-    
+        raise ValueError(
+            f'Unknown size "{size}". Size must be one of the following: "small", "medium" or "large"'
+        )
+
     for character in text:
         filename = _get_filename(character, size)
         n = 0
-        with open(filename, 'r') as c:
+        with open(filename, "r") as c:
             count = 0
             for line in c:
                 for j, k in enumerate(line):
                     if k in ["$"]:
-                        set_pixel(x+j, y+count, color)
+                        set_pixel(x + j, y + count, color)
                     n = j
                 count += 1
         x += n

--- a/casioplot/casioplot.py
+++ b/casioplot/casioplot.py
@@ -12,68 +12,113 @@ You can also use :py:data:`casioplot_settings` to change some behavior.
 
 from os import path
 from typing import Literal
-from PIL import Image
+from PIL import Image, ImageTk
+import tkinter as tk
 from configs import get_config
 
-
+# color type
 COLOR = tuple[int, int, int]
+# some frequently used colors
 _WHITE: COLOR = (255, 255, 255)  # RGBA white
 _BLACK: COLOR = (0, 0, 0)  # RGBA black
 # a list of all settings that if change should trigger the _redraw_screen function
 redraw_settings: tuple = ('width', 'height', 'left_margin', 'right_margin', 'top_margin', 'bottom_margin')
-
-# Create virtual screen
+# create virtual screen
 _screen: Image.Image = Image.new("RGB", (384, 192), _WHITE)
+# creates a tkinter window
+_window = tk.Tk()
+_window.grab_release()
+_window.geometry("384x192")
+_window.title("casioplot")
+_window.attributes("-topmost", True)
+# needed to display the screen in the tkinter window
+_photo_image = ImageTk.PhotoImage(_screen)
+_screen_display = tk.Label(_window, image=_photo_image)
+_screen_display.pack()
 
 
-class Casioplot_casioplot_settings:
+class Casioplot_settings:
     """Manage casioplot_settings for the casioplot module."""
 
     def __init__(self) -> None:
-        # all casioplot_settings are the default ones
-        # Size casioplot_settings
-        self.width: int = 384  # Screen width in pixels
-        self.height: int = 192  # Screen height in pixels
+        # canvas size
+        self.width: int  # canvas width in pixels
+        self.height: int  # canvas height in pixels
         # margins
-        self.left_margin: int = 0
-        self.right_margin: int = 0
-        self.top_margin: int = 0
-        self.bottom_margin: int = 0
+        self.left_margin: int
+        self.right_margin: int
+        self.top_margin: int
+        self.bottom_margin: int
         # background Image
-        self.background_image: Image.Image = Image.new("RGB", (384, 192), _WHITE)
-        # Output casioplot_settings
-        self.open_image: bool = False  # Open the screen
-        self.save_image: bool = True  # Save the screen as an image
-        # Saving casioplot_settings
-        self.filename: str = "casioplot"
-        self.image_format: str = "png"
+        self.background_image: Image.Image  # some configs like casio_graph_90_plus_e
+        # have a special background image
+        # Output settings
+        self.show_screen: bool  # Show the screen, do not misstake for the functin show_screen()
+        self.save_screen: bool  # Save the screen as an image
+        # Saving settings
+        self.filename: str
+        self.image_format: str
+
+        self.config_to('default')  # sets all settings to the default ones
+
+
+    def _screen_dimensions(self) -> tuple[int, int]:
+        """Calculates the dimensions of the screen"""
+        return (
+            self.left_margin + self.width + self.right_margin,
+            self.top_margin + self.height + self.bottom_margin
+        )
+
 
     def config_to(self, config: str = "default") -> None:
         global _screen
         for setting, value in get_config(config).items():
             setattr(self, setting, value)
+
+        # a configuration may have a background image
         _screen = self.background_image
+        # in case self.show_screen is altered
+        if self.show_screen is True:
+            _window.deiconify()
+        else:
+            _window.withdraw()
+        # in case the screen dimensions are altered
+        screen_width, screen_height = self._screen_dimensions()
+        _window.geometry(f"{screen_width}x{screen_height}")
+
 
     def set(self, **settings) -> None:
         """Set an attribute for each given setting with the corresponding value."""
         should_redraw_screen: bool = False
 
         for setting, value in settings.items():
+            if getattr(self, setting, None) is None:
+                raise AttributeError(f"There is no setting {setting}")
+
             if setting == 'background_image':
                 raise ValueError("you can't set background_image")
+
             elif setting in redraw_settings:
                 should_redraw_screen = True
+
+            elif setting == "show_screen":
+                if value is True:
+                    _window.deiconify()
+                else:
+                    _window.withdraw()
+
             setattr(self, setting, value)
 
         if should_redraw_screen:
             _redraw_screen()
+
 
     def get(self, setting: str):
         """Returns an attribute"""
         return getattr(self, setting)
 
 
-casioplot_settings = Casioplot_casioplot_settings()
+casioplot_settings = Casioplot_settings()
 
 
 def _redraw_screen() -> None:
@@ -83,20 +128,34 @@ def _redraw_screen() -> None:
     used to redraw _image with custom margins, width and height.
     """
     global _screen
+    screen_width, screen_height = casioplot_settings._screen_dimensions()
 
     # Create a new white image
-    _screen = Image.new(
-        "RGB",
-        (
-            casioplot_settings.get('left_margin') + casioplot_settings.get('width') +
-            casioplot_settings.get('right_margin'),
-            casioplot_settings.get('top_margin') + casioplot_settings.get('height') +
-            casioplot_settings.get('bottom_margin'),
-        ),
-        _WHITE,
-    )
-
+    _screen = Image.new("RGB", (screen_width, screen_height), _WHITE)
+    # update the background_image
     casioplot_settings.background_image = _screen
+    # updates the window dimensions
+    _window.geometry(f"{screen_width}x{screen_height}")
+
+
+def _coordenates_in_bounds(x: int, y: int) -> bool:
+    """Checks if the given coordenates are in bounds of the canvas
+
+    :param x: x coordinate (from the left)
+    :param y: y coordinate (from the top)
+    :return: a bool that says if the given coordenates are in bounds of the canvas
+    """
+    return 0 <= x < casioplot_settings.get("width") and 0 <= y < casioplot_settings.get("height")
+
+
+def _canvas_to_screen(x: int, y: int) -> tuple[int, int]:
+    """Translates coordenates of the canvas to coordenates in the virtual screen
+
+    :param x: x coordinate (from the left)
+    :param y: y coordinate (from the top)
+    :return: The coresponding coordenates in the virtual screen
+    """
+    return x + casioplot_settings.get("left_margin"), y + casioplot_settings.get("top_margin")
 
 
 def show_screen() -> None:
@@ -104,13 +163,15 @@ def show_screen() -> None:
 
     This function implement two modes that can be enabled or disabled using the :py:class:`casioplot_settings`:
       - Open the screen as an image (enabled using `casioplot_settings.get('open_image')`).
-      - Save the screen to the disk (enabled using `casioplot_settings.get('save_image')`).
+      - Save the screen to the disk (enabled using `casioplot_settings.get('save_screen')`).
         The image is saved with the filename found in `casioplot_settings.get('filename')`
     """
-    if casioplot_settings.get("open_image") is True:
-        # open the picture
-        _screen.show()
-    if casioplot_settings.get("save_image") is True:
+    if casioplot_settings.get("show_screen") is True:
+        # show the screen
+        _photo_image = ImageTk.PhotoImage(_screen)
+        _screen_display["image"] = _photo_image
+        _window.update()
+    if casioplot_settings.get("save_screen") is True:
         # Save the screen to the disk as an image with the given filename
         _screen.save(
             casioplot_settings.get("filename") + '.' + casioplot_settings.get("image_format"),
@@ -122,27 +183,7 @@ def clear_screen() -> None:
     """Clear the virtual screen."""
     for x in range(casioplot_settings.get('width')):
         for y in range(casioplot_settings.get('height')):
-            set_pixel(x, y, _WHITE)
-
-
-def coordenates_in_bounds(x: int, y: int) -> bool:
-    """Checks if the given coordenates are in bounds of the canvas
-
-    :param x: x coordinate (from the left)
-    :param y: y coordinate (from the top)
-    :return: a bool that says if the given coordenates are in bounds of the canvas
-    """
-    return 0 <= x < casioplot_settings.get("width") and 0 <= y < casioplot_settings.get("height")
-
-
-def canvas_to_screen(x: int, y: int) -> tuple[int, int]:
-    """Translates coordenates of the canvas to coordenates in the virtual screen
-
-    :param x: x coordinate (from the left)
-    :param y: y coordinate (from the top)
-    :return: The coresponding coordenates in the virtual screen
-    """
-    return x + casioplot_settings.get("left_margin"), y + casioplot_settings.get("top_margin")
+            set_pixel(*_canvas_to_screen(x, y), _WHITE)
 
 
 def get_pixel(x: int, y: int) -> COLOR | None:
@@ -152,8 +193,8 @@ def get_pixel(x: int, y: int) -> COLOR | None:
     :param y: y coordinate (from the top)
     :return: The pixel color. A tuple that contain 3 integers from 0 to 255 or None if the pixel is out of the canvas.
     """
-    if coordenates_in_bounds(x, y):
-        return _screen.getpixel(canvas_to_screen(x, y))
+    if _coordenates_in_bounds(x, y):
+        return _screen.getpixel(_canvas_to_screen(x, y))
     else:
         return None
 
@@ -165,15 +206,8 @@ def set_pixel(x: int, y: int, color: COLOR = _BLACK) -> None:
     :param y: y coordinate (from the top)
     :param color: The pixel color. A tuple that contain 3 integers from 0 to 255.
     """
-    if not 0 <= x < casioplot_settings.get("width") or not 0 <= y < casioplot_settings.get("height"):
-        return
-    _screen.putpixel(
-        (
-            x + casioplot_settings.get("left_margin"),
-            y + casioplot_settings.get("top_margin"),
-        ),
-        color,
-    )
+    if _coordenates_in_bounds(x, y):
+        _screen.putpixel(_canvas_to_screen(x, y), color)
 
 
 def _get_filename(character, size: Literal["small", "medium", "large"] = "medium"):

--- a/casioplot/casioplot.py
+++ b/casioplot/casioplot.py
@@ -7,7 +7,7 @@ Available functions:
   - :py:func:`clear_screen`
   - :py:func:`show_screen`
 
-You can also use :py:data:`settings` to change some behavior.
+You can also use :py:data:`casioplot_settings` to change some behavior.
 """
 
 from os import path
@@ -24,12 +24,12 @@ _BLACK: COLOR = (0, 0, 0)  # RGBA black
 _image: Image.Image = Image.new("RGB", (384, 192), _WHITE)
 
 
-class casioplot_settings:
-    """Manage settings for the casioplot module."""
+class Casioplot_casioplot_settings:
+    """Manage casioplot_settings for the casioplot module."""
 
     def __init__(self) -> None:
-        # all settings are the default ones
-        # Size settings
+        # all casioplot_settings are the default ones
+        # Size casioplot_settings
         self.width: int = 384  # Screen width in pixels
         self.height: int = 192  # Screen height in pixels
         # margins
@@ -39,10 +39,10 @@ class casioplot_settings:
         self.bottom_margin: int = 0
         # background Image
         self.background_image: Image.Image = Image.new("RGB", (384, 192), _WHITE)
-        # Output settings
+        # Output casioplot_settings
         self.open_image: bool = False  # Open the screen
         self.save_image: bool = True  # Save the screen as an image
-        # Saving settings
+        # Saving casioplot_settings
         self.filename: str = "casioplot.png"
         self.image_format: str = "png"
 
@@ -52,9 +52,9 @@ class casioplot_settings:
             setattr(self, setting, value)
         _image = self.background_image
 
-    def set(self, **settings) -> None:
+    def set(self, **casioplot_settings) -> None:
         """Set an attribute for each given setting with the corresponding value."""
-        for setting, value in settings.items():
+        for setting, value in casioplot_settings.items():
             setattr(self, setting, value)
         _redraw_screen()
 
@@ -63,13 +63,13 @@ class casioplot_settings:
         return getattr(self, setting)
 
 
-settings = casioplot_settings()
+casioplot_settings = Casioplot_casioplot_settings()
 
 
 def _redraw_screen() -> None:
     """Redraws _image.
 
-    Only called when settings.set() is called,
+    Only called when casioplot_settings.set() is called,
     used to redraw _image with custom margins, width and height.
     """
     global _image
@@ -78,38 +78,39 @@ def _redraw_screen() -> None:
     _image = Image.new(
         "RGB",
         (
-            settings.left_margin + settings.width + settings.right_margin,
-            settings.top_margin + settings.height + settings.bottom_margin,
+            casioplot_settings.left_margin + casioplot_settings.width + casioplot_settings.right_margin,
+            casioplot_settings.top_margin + casioplot_settings.height + casioplot_settings.bottom_margin,
         ),
         _WHITE,
     )
 
-    settings.background_image = _image
+    casioplot_settings.background_image = _image
 
 
 def show_screen() -> None:
     """Show or saves the virtual screen
 
-    This function implement two modes that can be enabled or disabled using the :py:class:`settings`:
-      - Open the screen as an image (enabled using `settings.get('open_image')`).
-      - Save the screen to the disk (enabled using `settings.get('save_image')`).
-        The image is saved with the filename found in `settings.get('filename')`
+    This function implement two modes that can be enabled or disabled using the :py:class:`casioplot_settings`:
+      - Open the screen as an image (enabled using `casioplot_settings.get('open_image')`).
+      - Save the screen to the disk (enabled using `casioplot_settings.get('save_image')`).
+        The image is saved with the filename found in `casioplot_settings.get('filename')`
     """
-    if settings.get("open_image") is True:
+    if casioplot_settings.get("open_image") is True:
         # open the picture
         _image.show()
-    if settings.get("save_image") is True:
+    if casioplot_settings.get("save_image") is True:
         # Save the screen to the disk as an image with the given filename
         _image.save(
-            settings.get("filename"),
-            format=settings.get("image_format"),
+            casioplot_settings.get("filename"),
+            format=casioplot_settings.get("image_format"),
         )
 
 
 def clear_screen() -> None:
     """Clear the virtual screen."""
-    show_screen()
-    settings.config_to("default")
+    for x in range(casioplot_settings.get('width')):
+        for y in range(casioplot_settings.get('height')):
+            set_pixel(x, y, _WHITE)
 
 
 def get_pixel(x: int, y: int) -> COLOR | None:
@@ -119,15 +120,15 @@ def get_pixel(x: int, y: int) -> COLOR | None:
     :param y: y coordinate (from the top)
     :return: The pixel color. A tuple that contain 3 integers from 0 to 255 or None if the pixel is out of the screen.
     """
-    if not 0 <= x < settings.get("width") or not 0 <= y < settings.get("height"):
+    if not 0 <= x < casioplot_settings.get("width") or not 0 <= y < casioplot_settings.get("height"):
         return None
     r: int
     g: int
     b: int
     r, g, b = _image.getpixel(
         (
-            x + settings.get("left_margin"),
-            y + settings.get("top_margin"),
+            x + casioplot_settings.get("left_margin"),
+            y + casioplot_settings.get("top_margin"),
         )
     )
     return r, g, b
@@ -140,12 +141,12 @@ def set_pixel(x: int, y: int, color: COLOR = _BLACK) -> None:
     :param y: y coordinate (from the top)
     :param color: The pixel color. A tuple that contain 3 integers from 0 to 255.
     """
-    if not 0 <= x < settings.get("width") or not 0 <= y < settings.get("height"):
+    if not 0 <= x < casioplot_settings.get("width") or not 0 <= y < casioplot_settings.get("height"):
         return
     _image.putpixel(
         (
-            x + settings.get("left_margin"),
-            y + settings.get("top_margin"),
+            x + casioplot_settings.get("left_margin"),
+            y + casioplot_settings.get("top_margin"),
         ),
         color,
     )

--- a/casioplot/casioplot.py
+++ b/casioplot/casioplot.py
@@ -19,6 +19,8 @@ from configs import get_config
 COLOR = tuple[int, int, int]
 _WHITE: COLOR = (255, 255, 255)  # RGBA white
 _BLACK: COLOR = (0, 0, 0)  # RGBA black
+# a list of all settings that if change should trigger the _redraw_screen function
+redraw_settings = ('width', 'height', 'left_margin', 'right_margin', 'top_margin', 'bottom_margin')
 
 # Create virtual screen
 _image: Image.Image = Image.new("RGB", (384, 192), _WHITE)
@@ -43,7 +45,7 @@ class Casioplot_casioplot_settings:
         self.open_image: bool = False  # Open the screen
         self.save_image: bool = True  # Save the screen as an image
         # Saving casioplot_settings
-        self.filename: str = "casioplot.png"
+        self.filename: str = "casioplot"
         self.image_format: str = "png"
 
     def config_to(self, config: str = "default") -> None:
@@ -52,11 +54,19 @@ class Casioplot_casioplot_settings:
             setattr(self, setting, value)
         _image = self.background_image
 
-    def set(self, **casioplot_settings) -> None:
+    def set(self, **settings) -> None:
         """Set an attribute for each given setting with the corresponding value."""
-        for setting, value in casioplot_settings.items():
+        should_redraw_screen: bool = False
+
+        for setting, value in settings.items():
+            if setting == 'background_image':
+                raise ValueError("you can't set background_image")
+            elif setting in redraw_settings:
+                should_redraw_screen = True
             setattr(self, setting, value)
-        _redraw_screen()
+
+        if should_redraw_screen:
+            _redraw_screen()
 
     def get(self, setting: str):
         """Returns an attribute"""
@@ -78,8 +88,10 @@ def _redraw_screen() -> None:
     _image = Image.new(
         "RGB",
         (
-            casioplot_settings.left_margin + casioplot_settings.width + casioplot_settings.right_margin,
-            casioplot_settings.top_margin + casioplot_settings.height + casioplot_settings.bottom_margin,
+            casioplot_settings.get('left_margin') + casioplot_settings.get('width') +
+            casioplot_settings.get('right_margin'),
+            casioplot_settings.get('top_margin') + casioplot_settings.get('height') +
+            casioplot_settings.get('bottom_margin'),
         ),
         _WHITE,
     )
@@ -101,7 +113,7 @@ def show_screen() -> None:
     if casioplot_settings.get("save_image") is True:
         # Save the screen to the disk as an image with the given filename
         _image.save(
-            casioplot_settings.get("filename"),
+            casioplot_settings.get("filename") + '.' + casioplot_settings.get("image_format"),
             format=casioplot_settings.get("image_format"),
         )
 

--- a/casioplot/configs.py
+++ b/casioplot/configs.py
@@ -16,9 +16,9 @@ configs = {
         'top_margin': 0,
         'bottom_margin': 0,
         'background_image': Image.new('RGB', (384, 192), _WHITE),
-        'open_image': False,
-        'save_image': True,
-        'filename': 'casioplot.png',
+        'show_screen': True,
+        'save_screen': False,
+        'filename': 'casioplot',
         'image_format': 'png'
     },
     'casio_graph_90_plus_e': {
@@ -31,9 +31,9 @@ configs = {
         'background_image': Image.open(
             path.join(_images_directory, "CASIO_Graph_90+e_empty.png")
         ).convert('RGB'),
-        'open_image': False,
-        'save_image': True,
-        'filename': 'casioplot.png',
+        'show_screen': True,
+        'save_screen': False,
+        'filename': 'casioplot',
         'image_format': 'png'
     }
 }

--- a/casioplot/configs.py
+++ b/casioplot/configs.py
@@ -1,0 +1,45 @@
+from PIL import Image
+from os import path
+
+_WHITE: tuple[int, int, int] = (255, 255, 255)  # RGBA white
+_images_directory = path.join(
+    path.abspath(path.dirname(__file__)),
+    "images"
+)
+
+configs = {
+    'default': {
+        'width': 384,
+        'height': 192,
+        'left_margin': 0,
+        'right_margin': 0,
+        'top_margin': 0,
+        'bottom_margin': 0,
+        'background_image': Image.new('RGB', (384, 192), _WHITE),
+        'open_image': False,
+        'save_image': True,
+        'filename': 'casioplot.png',
+        'image_format': 'png'
+    },
+    'casio_graph_90_plus_e': {
+        'width': 384,
+        'height': 192,
+        'left_margin': 0,
+        'right_margin': 0,
+        'top_margin': 24,
+        'bottom_margin': 0,
+        'background_image': Image.open(
+            path.join(_images_directory, "CASIO_Graph_90+e_empty.png")
+        ).convert('RGB'),
+        'open_image': False,
+        'save_image': True,
+        'filename': 'casioplot.png',
+        'image_format': 'png'
+    }
+}
+
+
+def get_config(config: str) -> dict:
+    if config not in configs.keys():
+        raise ValueError(f"No config called {config}")
+    return configs[config]


### PR DESCRIPTION
I added the following functions _coordenates_in_bound, _canvas_to_screen and _screen_size.
Renamed _clear_screen to _redraw_screen.
Change the class casio_settings to use instance attributes instead of class attributes, thought it would be more appropriate.
Added support to showing the screen with tkinter.
Created the file configs.py, removed the methods casio_graph_90_plus_e and default and created the method config_to and the function get_config, in order to make the configuration system more expandable.
Also removed _draw, it didn't seem to have a use.