### PR TITLE
Added the option correct_colors

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -154,11 +154,20 @@ where ``number`` is the number of the save.
     image_name = "casioplot"
     image_format = "png"
     save_multiple = false
-    # be careful, with save_rate = 1 you can easly generate tens of thousand of images in a few seconds
-    save_rate = 1  
+    # be careful, with save_rate = 1 you can easily generate tens of thousand of images in a few seconds
+    save_rate = 1
 
-It could also be helpfull to see `fx-CG50.toml <https://github.com/uniwix/casioplot/blob/master/casioplot/presets/fx-CG50.toml>`_.
-It loks like this:
+The Casio calculators don't have the same precision for colors as the computer
+the option :toml:`correct_colors` makes the :py:func:`set_pixel` function correct the colors
+to match what would happen in the calculators
+
+.. code-block:: toml
+
+    [colors]
+    correct_colors = false
+
+It could also be helpful to see `fx-CG50.toml <https://github.com/uniwix/casioplot/blob/master/casioplot/presets/fx-CG50.toml>`_.
+It looks like this:
 
 .. image:: images/calculator.png
     :alt: Empty casio calculator screen

--- a/src/casioplot/casioplot.py
+++ b/src/casioplot/casioplot.py
@@ -124,6 +124,13 @@ def set_pixel(x: int, y: int, color: Color = _BLACK) -> None:
     :param color: The pixel color. A tuple that contain 3 integers from 0 to 255
     """
     try:
+        if _settings["correct_colors"] is True:  # corrects the colors to match the behavior of the casio calculators
+            color = (  # there may be a faster way
+                color[0] - color[0] % 8,
+                color[1] - color[1] % 4,
+                color[2] - color[2] % 8
+            )
+
         _canvas.put(
             "#%02x%02x%02x" % color,  # convert the color (RGB tuple) to a hexadecimal string '#RRGGBB'
             to=(x, y)
@@ -219,6 +226,7 @@ try:
     :meta hide-value:
     """
     _canvas_display.place(x=_settings["left_margin"], y=_settings["top_margin"])
+
 except tk.TclError:
     print("The tkinter window couldn't be created. The screen won't be shown.")
 

--- a/src/casioplot/presets/default.toml
+++ b/src/casioplot/presets/default.toml
@@ -63,3 +63,8 @@ image_name = "casioplot"
 image_format = "png"
 save_multiple = false
 save_rate = 1
+
+# the casio calculators don't have the same precission for colors as the computer
+# the option `correct_colors` makes the set_pixel function correct the colors to match what would happen in the calculators
+[colors]
+correct_colors = false

--- a/src/casioplot/presets/fx-CG50.toml
+++ b/src/casioplot/presets/fx-CG50.toml
@@ -22,3 +22,6 @@ image_name = "casioplot"
 image_format = "png"
 save_multiple = false
 save_rate = 1
+
+[colors]
+correct_colors = true

--- a/src/casioplot/presets/fx-CG50.toml
+++ b/src/casioplot/presets/fx-CG50.toml
@@ -14,7 +14,7 @@ background_image = "bg_images/calculator.png"
 
 [showing_screen]
 show_screen = true
-close_window = true
+close_window = false
 
 [saving_screen]
 save_screen = false

--- a/src/casioplot/settings.py
+++ b/src/casioplot/settings.py
@@ -147,7 +147,7 @@ def _get_configuration_from_file(file_path: str) -> tuple[Configuration, str]:
             "save_rate"
         ),
         "colors": (
-            "correct_colors"
+            "correct_colors",
         ),
     }
 

--- a/src/casioplot/settings.py
+++ b/src/casioplot/settings.py
@@ -145,7 +145,10 @@ def _get_configuration_from_file(file_path: str) -> tuple[Configuration, str]:
             "image_format",
             "save_multiple",
             "save_rate"
-        )
+        ),
+        "colors": (
+            "correct_colors"
+        ),
     }
 
     def _check_toml(toml: dict) -> None:

--- a/src/casioplot/types.py
+++ b/src/casioplot/types.py
@@ -35,7 +35,7 @@ class Configuration(TypedDict, total=False):
     save_rate: int  # if `save_multiple is True a new image will be saved`
     # every `save_rate` times show_screen is called
 
-    correct_colors: bool  # the colors on the casio calculators don't have the same precission as the computer
+    correct_colors: bool  # the casio calculators don't have the same precission for colors as the computer
     # this options makes the set_pixel function correct the colors to match what would happen in the calculators
 
 Color = tuple[int, int, int]

--- a/src/casioplot/types.py
+++ b/src/casioplot/types.py
@@ -4,8 +4,8 @@ from typing import TypedDict, Literal
 
 
 class Configuration(TypedDict, total=False):
-    """The type :py:class:`Configuration` makes it possible to representing all settings and configs in a dictionary but still
-    have type annotations for every setting.
+    """The type :py:class:`Configuration` makes it possible to representing all settings and configs in a dictionary
+    but still have type annotations for every setting.
     The option :python:`total=False` makes it possible for a configuration to not have a value for all settings"""
 
     # canvas size
@@ -35,6 +35,8 @@ class Configuration(TypedDict, total=False):
     save_rate: int  # if `save_multiple is True a new image will be saved`
     # every `save_rate` times show_screen is called
 
+    correct_colors: bool  # the colors on the casio calculators don't have the same precission as the computer
+    # this options makes the set_pixel function correct the colors to match what would happen in the calculators
 
 Color = tuple[int, int, int]
 """A color is represented as a tuple of three integers, each integer is in the range [0, 255] and represents the


### PR DESCRIPTION
The casio calculators don't have much precision for displaying colors, this option simulates this behavior. The colors on the calculator work on the following increments (in the computer it is 1):
- r 8
- g 4
- b 8